### PR TITLE
Be able to used the overrided setPath.

### DIFF
--- a/plugins/restful/RestfulBase.php
+++ b/plugins/restful/RestfulBase.php
@@ -670,7 +670,7 @@ abstract class RestfulBase extends \RestfulPluginBase implements \RestfulInterfa
       $this->getRateLimitManager()->checkRateLimit($request);
     }
 
-    return $this->{$method_name}($path);
+    return $this->{$method_name}($this->path);
   }
 
   /**


### PR DESCRIPTION
Line 652 sets the path, but does not allow it to be overridden when handed off to the next method.
